### PR TITLE
feat: Specify HTTPRoutes called by GitHub Webhook

### DIFF
--- a/config/github-app/gateway/httproute.yaml
+++ b/config/github-app/gateway/httproute.yaml
@@ -8,13 +8,26 @@ spec:
     - name: pr-agent-gateway
       namespace: default
   rules:
-  - backendRefs:
-    - name: pr-agent-service
-      port: 80
-    # - matches:
-    #     - path:
-    #         type: PathPrefix
-            # value: /
+    # Rule for GET requests to /
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+          method: GET
+      backendRefs:
+        - name: pr-agent-service
+          port: 80
+
+    # Rule for POST requests to /api/v1/github_webhooks
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/v1/github_webhooks
+          method: POST
+      backendRefs:
+        - name: pr-agent-service
+          port: 80
+
 
 # apiVersion: gateway.networking.k8s.io/v1beta1
 # kind: HTTPRoute


### PR DESCRIPTION
### **User description**
Specify the HTTP Routes called by GitHub Webhook


___

### **PR Type**
enhancement


___

### **Description**
- Added support for GET and POST requests to specific paths.

- Updated HTTPRoute configuration to handle GitHub Webhook requests.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>httproute.yaml</strong><dd><code>Update HTTPRoute for GitHub Webhook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/github-app/gateway/httproute.yaml

<li>Added GET and POST rules for specific paths.<br> <li> Updated backend references for the routes.


</details>


  </td>
  <td><a href="https://github.com/ishaansehgal99/kaito-pr-review-demo/pull/8/files#diff-c856545c7db947115745f85cc7765431a07b7ddd538d6cdcad3106846ae4198b">+20/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>